### PR TITLE
Fixed problems with IO Websocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pubspec.lock
 # Directory created by dartdoc
 # If you don't generate documentation locally you can remove this line.
 doc/api/
+.dart_tool
+.idea

--- a/lib/mqtt_client.dart
+++ b/lib/mqtt_client.dart
@@ -198,7 +198,11 @@ class MqttClient<E extends VirtualMqttConnection> {
        _remData.addAll(data);
      } else {
        // No remaining data
-       _remData = Uint8List.fromList(data);
+         if (data is ByteBuffer) {
+             _remData = data.asUint8List();
+         } else {
+             _remData = Uint8List.fromList(data);
+         }
      }
 
      var lenBefore, lenAfter;

--- a/lib/mqtt_client.dart
+++ b/lib/mqtt_client.dart
@@ -198,7 +198,7 @@ class MqttClient<E extends VirtualMqttConnection> {
        _remData.addAll(data);
      } else {
        // No remaining data
-       _remData = data.asUint8List();
+       _remData = Uint8List.fromList(data);
      }
 
      var lenBefore, lenAfter;

--- a/lib/mqtt_connection_io_websocket.dart
+++ b/lib/mqtt_connection_io_websocket.dart
@@ -11,7 +11,11 @@ class MqttConnectionIOWebSocket extends VirtualMqttConnection{
   MqttConnectionIOWebSocket.setOptions(this._url);
   Future connect() {
     print("[WebSocket] Connecting to $_url");
-    return WebSocket.connect(_url);
+    return WebSocket.connect(_url, protocols: [
+      'mqtt',
+      'mqttv3.1',
+      'mqttv3.11'
+    ]);
   }
   
   handleConnectError(e) {


### PR DESCRIPTION
When I tested using the IO Websocket, I ran into two issues:
1. Socket wasn't upgraded
2. Invalid cast

I fixed the first issue by supplying a protocols list.

The second problem is fixed by doing a `Uint8List.fromList(data)` instead of `data.asUint8List()`